### PR TITLE
Add support for VPC flow logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ Current status: **beta release**
 
 ## Overview
 
-This is a beat for the AWS services that can export logs to S3, like [Amazon Web Services (AWS) CloudTrail](https://aws.amazon.com/cloudtrail/) service.  S3AWSLogBeat relies on a combination of SNS, SQS and S3 to create a processing 'pipeline' to process new log events quickly and efficiently.  The beat polls the SQS queue for notification of when a new log file is available for download in S3.  Each log file is then downloaded, processed and sent to the configured receiver (logstash, elasticsearch, etc).  You are then able to query the data using Kibana (or any other tool) to analyse events involving API calls and IAM authentications.
+This is a beat for the AWS services that can export logs to S3  S3AWSLogBeat relies on a combination of SNS, SQS and S3 to create a processing 'pipeline' to process new log events quickly and efficiently.  The beat polls the SQS queue for notification of when a new log file is available for download in S3.  Each log file is then downloaded, processed and sent to the configured receiver (logstash, elasticsearch, etc).  You are then able to query the data using Kibana (or any other tool) to analyse events involving API calls and IAM authentications.
+
+Types of logs supported:
+* [Amazon Web Services (AWS) CloudTrail](https://aws.amazon.com/cloudtrail/)
+* [Amazon Web Services (AWS) VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html)
+* GuardDuty (coming soon)
+* ECS Container Scanning (coming soon)
 
 ## Getting Started
 ### Requirements
@@ -26,7 +32,7 @@ docker build . -t s3awslogbeat:latest
 
 Confguring CloudTrail is relatively straight forward and can be done quite easily through the AWS web console.  The [official documentation](http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-and-update-a-trail.html) outlines the steps required to configure everything, just ensure you complete the optional step 3.
 
-If you would prefer to use CloudFormation to configure your environment, you can use the [provided template](conf/cloudtrail_cf.template) which will configure all of the neccessary services (CloudTrail, S3, SQS).   
+Confguring VPCFlowLogBeat is relatively straight forward and can be done quite easily through the AWS web console.  The [official documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) outlines the steps required to configure everything.
 
 Once configured, you can confirm everything is working by inspecting the configured S3 bucket as well as the SQS queue.
 
@@ -79,13 +85,14 @@ S3AWSLogBeat supports usage of both IAM roles and API keys, but as per AWS best 
 1. Build S3AWSLogBeat using the steps list above
 2. Modify the included *s3awslogbeat.yml* file as required
   1. Change the *sqs_url* field under the *input* section with the appropriate SQS url
-  2. Configure the *output* section to send the events to your logstash/elasticsearch instance.  More information on Beat output configuration can be found in the [official documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration-details.html). 
+  2. Configure the *log_mode* field under the *input* section with the appropriate type of log being ingested.
+  3. Configure the *output* section to send the events to your logstash/elasticsearch instance.  More information on Beat output configuration can be found in the [official documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration-details.html). 
 3. If you are not using IAM Roles to grant access to the SQS and S3 buckets, you will also need to configure *~/.aws/credentials* with the an appropriate key and secret.  The [AWS docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) give a thorough explanation on setting up the required credentials files. 
 4. Run S3AWSLogBeat in debug mode: `s3awslogbeat -c /path/to/s3awslogbeat.yml -d "*"`
 
 You should now see a bunch of events scrolling through your terminal and in your output source.
 
-If you are happy with the output, you will need to edit the configuration file to set `no_purge` to `false` (or delete the line).
+If you are happy with the output, you will need to edit the configuration file to set `no_purge` to `false` (or delete the line). This will ensure SQS messages are removed from the queue as they are processed.
 
 #### Backfilling
 
@@ -99,8 +106,5 @@ If you would like to backfill only a subset of a bucket, you can also include th
 
 ## Thanks
 
-This beat is based originally on a fork of [taxibeat/CloudTrailBeat](https://github.com/taxibeat/cloudtrailbeat). That beat is heavily inspired by [AppliedTrust/traildash](https://github.com/AppliedTrust/traildash) with some updates and additional functionality.
-
-## Todo
-
-- Configurable "type" of retrieved logs (CloudTrail, VPC Flow Logs, GuardDuty, etc)
+This beat is based originally on a fork of [taxibeat/CloudTrailBeat](https://github.com/taxibeat/cloudtrailbeat).
+That beat is heavily inspired by [AppliedTrust/traildash](https://github.com/AppliedTrust/traildash) with some updates and additional functionality.

--- a/beater/cloudtrail_functions.go
+++ b/beater/cloudtrail_functions.go
@@ -1,9 +1,19 @@
 package beater
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"strings"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher"
 )
 
 // data struct matching the defined fields of a CloudTrail Record as
@@ -30,7 +40,6 @@ type cloudtrailEvent struct {
 	APIVersion			string					`json:"apiVersion"`
 	RecipientAccountID	string					`json:"recipientAccountID"`
 }
-
 
 type cloudtrailEventFieldFunction func(e *cloudtrailEvent) interface{}
 
@@ -71,4 +80,65 @@ func cloudtrailMatchPattern(event cloudtrailEvent, field string, search string) 
 		}
 	}
 	return false
+}
+
+func (logbeat *S3AwsLogBeat) publishCloudTrailEvents(logs cloudtrailLog) error {
+	if len(logs.Records) < 1 {
+		return nil
+	}
+
+	events := make([]common.MapStr, 0, len(logs.Records))
+
+	for _, logEvent := range logs.Records {
+		timestamp, err := time.Parse(logTimeFormat, logEvent.EventTime)
+
+		if err != nil {
+			logp.Err("Unable to parse EventTime : %s", logEvent.EventTime)
+		}
+
+		for _, counter := range logbeat.customCounterMetrics {
+			if cloudtrailMatchPattern(logEvent, counter.Field, counter.Match) {
+				counter.Counter.Inc()
+			}
+		}
+
+		le := common.MapStr{
+			"@timestamp": common.Time(timestamp),
+			"type":	   "CloudTrail",
+			"cloudtrail": logEvent,
+		}
+
+		events = append(events, le)
+	}
+	if !logbeat.events.PublishEvents(events, publisher.Sync, publisher.Guaranteed) {
+		logbeat.eventsProcessedErrors.Add(float64(len(events)))
+		return fmt.Errorf("Error publishing events")
+	}
+	logbeat.eventsProcessed.Add(float64(len(events)))
+
+	return nil
+}
+
+func (logbeat *S3AwsLogBeat) readCloudTrailLogfile(m sqsNotificationMessage) (cloudtrailLog, error) {
+	events := cloudtrailLog{}
+
+	s := s3.New(session.New(logbeat.awsConfig))
+	q := s3.GetObjectInput{
+		Bucket: aws.String(m.S3Bucket),
+		Key:	aws.String(m.S3ObjectKey[0]),
+	}
+	o, err := s.GetObject(&q)
+	if err != nil {
+		return events, err
+	}
+	b, err := ioutil.ReadAll(o.Body)
+	if err != nil {
+		return events, err
+	}
+
+	if err := json.Unmarshal(b, &events); err != nil {
+		return events, fmt.Errorf("Error unmarshaling cloutrail JSON: %s", err.Error())
+	}
+
+	return events, nil
 }

--- a/beater/cloudtrail_functions.go
+++ b/beater/cloudtrail_functions.go
@@ -122,7 +122,7 @@ func (logbeat *S3AwsLogBeat) publishCloudTrailEvents(logs cloudtrailLog) error {
 func (logbeat *S3AwsLogBeat) readCloudTrailLogfile(m sqsNotificationMessage) (cloudtrailLog, error) {
 	events := cloudtrailLog{}
 
-	s := s3.New(session.New(logbeat.awsConfig))
+	s := s3.New(session.New(logbeat.awsS3Config))
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3Bucket),
 		Key:	aws.String(m.S3ObjectKey[0]),

--- a/beater/s3awslogbeat.go
+++ b/beater/s3awslogbeat.go
@@ -130,7 +130,7 @@ func New() *S3AwsLogBeat {
 		})
 	logbeat.notificationsProcessedErrors = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "s3_awslogs_beat_file_errors",
+			Name: "s3_awslogs_beat_notifications_errors",
 			Help: "The total number of errors ingesting SQS notifications",
 		})
 

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,9 +140,9 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
-	logbeat.awsConfig = logbeat.awsConfig.WithRegion(m.AwsRegion)
+	localAwsConfig = logbeat.awsConfig.WithRegion(m.AwsRegion)
 
-	s := s3.New(session.New(logbeat.awsConfig))
+	s := s3.New(session.New(localAwsConfig))
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),
 		Key:	aws.String(m.S3.Object.Key),
@@ -310,7 +310,8 @@ func (logbeat *S3AwsLogBeat) getRowIndexValue(field string) (int) {
 	if index, ok := logbeat.csvFields[field]; ok {
 		returnValue = index
 	}
-	logp.Debug("vpcflowlogbeat", "getRowIndexValue %v yields %v", field, returnValue)
+	/* Too noisy even for debug mode
+	logp.Debug("vpcflowlogbeat", "getRowIndexValue %v yields %v", field, returnValue) */
 	return returnValue
 }
 

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,7 +140,7 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
-	localAwsConfig = logbeat.awsConfig.WithRegion(m.AwsRegion)
+	var localAwsConfig := logbeat.awsConfig.WithRegion(m.AwsRegion)
 
 	s := s3.New(session.New(localAwsConfig))
 	q := s3.GetObjectInput{

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -111,6 +111,7 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 
 		if err != nil {
 			logp.Err("Unable to parse EventTime : %s", logEvent.EventTime)
+			logbeat.eventsProcessedErrors.Add(float64(len(events)))
 		}
 
 		for _, counter := range logbeat.customCounterMetrics {

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,7 +140,7 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
-	var localAwsConfig := logbeat.awsConfig.WithRegion(m.AwsRegion)
+	localAwsConfig := logbeat.awsConfig.WithRegion(m.AwsRegion)
 
 	s := s3.New(session.New(localAwsConfig))
 	q := s3.GetObjectInput{

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,9 +140,9 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
-	localAwsConfig := logbeat.awsConfig.WithRegion(m.AwsRegion)
+	logbeat.awsS3Config = logbeat.awsS3Config.WithRegion(m.AwsRegion)
 
-	s := s3.New(session.New(localAwsConfig))
+	s := s3.New(session.New(logbeat.awsS3Config))
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),
 		Key:	aws.String(m.S3.Object.Key),

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,7 +140,7 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
-	logbeat.awsS3Config = logbeat.awsS3Config.WithRegion(m.AwsRegion)
+	logbeat.awsConfig = logbeat.awsConfig.WithRegion(m.AwsRegion)
 
 	s := s3.New(session.New(logbeat.awsConfig))
 	q := s3.GetObjectInput{

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -1,0 +1,321 @@
+package beater
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"encoding/csv"
+	"io"
+	"strconv"
+	"compress/gzip"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher"
+)
+
+// data struct matching the defined fields of a vpcFlowLog Record as
+//  described in:
+//  https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-logs-fields
+type vpcFlowLog struct {
+	Records []vpcFlowLogEvent
+}
+type vpcFlowLogEvent struct {
+	EventTime		string	`json:"eventTime"`
+	Ipv4SrcAddr		string	`json:"ipv4_src_addr"`
+	Ipv6SrcAddr		string	`json:"ipv6_src_addr"`
+	Ipv4DstAddr		string	`json:"ipv4_dst_addr"`
+	Ipv6DstAddr		string	`json:"ipv6_dst_addr"`
+	L4SrcPort		int64	`json:"l4_src_port"`
+	L4DstPort		int64	`json:"l4_dst_port"`
+	Protocol		int64	`json:"protocol"`
+	InPkts			int64	`json:"in_pkts"`
+	InBytes			int64	`json:"in_bytes"`
+	Direction		int64	`json:"direction"`
+	AwsDetails			struct {
+		Version				string	`json:"version"`
+		AccountId			int64	`json:"account_id"`
+		InterfaceId			string	`json:"interface_id"`
+		Start				int64	`json:"start"`
+		End					int64	`json:"end"`
+		Action				string	`json:"action"`
+		LogStatus			string	`json:"log_status"`
+		VpcId				string	`json:"vpc_id"`
+		SubnetId			string	`json:"subnet_id"`
+		InstanceId			string	`json:"instance_id"`
+		TcpFlags			[]string	`json:"tcp_flags"`
+		Type				string	`json:"type"`
+		PktSrcAddr			string	`json:"pkg_src_addr"`
+		PktDstAddr			string	`json:"pkg_dst_addr"`
+		Region				string	`json:"region"`
+		AzId				string	`json:"az_id"`
+		SublocationType		string	`json:"sublocation_type"`
+		SublocationId		string	`json:"sublocation_id"`
+		PktSrcAwsService	string	`json:"pkt_src_aws_service"`
+		PktDstAwsService	string	`json:"pkt_dst_aws_service"`
+		FlowDirection		string	`json:"flow_direction"`
+		TrafficPath			string	`json:"traffic_path"`
+	}	`json:"aws_details"`
+}
+
+type vpcFlowLogEventFieldFunction func(e *vpcFlowLogEvent) interface{}
+
+var vpcFlowLogEventField = map[string]vpcFlowLogEventFieldFunction{
+    "eventTime": func(e *vpcFlowLogEvent) interface{}     { return e.EventTime },
+    "ipv4_src_addr": func(e *vpcFlowLogEvent) interface{} { return e.Ipv4SrcAddr },
+    "ipv6_src_addr": func(e *vpcFlowLogEvent) interface{} { return e.Ipv6SrcAddr },
+    "ipv4_dst_addr": func(e *vpcFlowLogEvent) interface{} { return e.Ipv4DstAddr },
+    "ipv6_dst_addr": func(e *vpcFlowLogEvent) interface{} { return e.Ipv6DstAddr },
+    "l4_src_port": func(e *vpcFlowLogEvent) interface{}   { return e.L4SrcPort },
+    "l4_dst_port": func(e *vpcFlowLogEvent) interface{}   { return e.L4DstPort },
+    "protocol": func(e *vpcFlowLogEvent) interface{}      { return e.Protocol },
+    "in_pkts": func(e *vpcFlowLogEvent) interface{}       { return e.InPkts },
+    "in_bytes": func(e *vpcFlowLogEvent) interface{}      { return e.InBytes },
+    "direction": func(e *vpcFlowLogEvent) interface{}     { return e.Direction },
+    "aws_details": func(e *vpcFlowLogEvent) interface{}   { return e.AwsDetails },
+}
+
+func vpcFlowLogMatchPattern(event vpcFlowLogEvent, field string, search string) bool {
+	if strings.Contains(field, ".") {
+		parts := strings.SplitN(field, ".", 2)
+		logp.Debug("s3awslogbeat", "need to find %s in event.%s[\"%s\"] (EventTime: %+v)\n", search, parts[0], parts[1], event.EventTime)
+		if mapToSearch := vpcFlowLogEventField[parts[0]](&event); mapToSearch != nil {
+			logp.Debug("s3awslogbeat", "mapToSearch: %+v\n", mapToSearch)
+			if fieldToSearch := mapToSearch.(map[string]interface{})[parts[1]]; fieldToSearch != nil {
+				logp.Debug("s3awslogbeat", "fieldToSearch: %+v\n", fieldToSearch)
+				return strings.Contains(fieldToSearch.(string), search)
+			}
+		}
+	} else {
+		logp.Debug("s3awslogbeat", "need to find %s in event.%s (EventTime: %+v)\n", search, field, event.EventTime)
+		if fieldToSearch := vpcFlowLogEventField[field](&event); fieldToSearch != nil {
+			return strings.Contains(fieldToSearch.(string), search)
+		}
+	}
+	return false
+}
+
+func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
+	if len(logs.Records) < 1 {
+		return nil
+	}
+
+	events := make([]common.MapStr, 0, len(logs.Records))
+
+	for _, logEvent := range logs.Records {
+		timestamp, err := time.Parse(logTimeFormat, logEvent.EventTime)
+
+		if err != nil {
+			logp.Err("Unable to parse EventTime : %s", logEvent.EventTime)
+		}
+
+		for _, counter := range logbeat.customCounterMetrics {
+			if vpcFlowLogMatchPattern(logEvent, counter.Field, counter.Match) {
+				counter.Counter.Inc()
+			}
+		}
+
+		le := common.MapStr{
+			"@timestamp": common.Time(timestamp),
+			"type":	   "VpcFlowLog",
+			"netflow": logEvent,
+			"ip_version": logEvent.AwsDetails.Type,
+		}
+
+		events = append(events, le)
+	}
+	if !logbeat.events.PublishEvents(events, publisher.Sync, publisher.Guaranteed) {
+		logbeat.eventsProcessedErrors.Add(float64(len(events)))
+		return fmt.Errorf("Error publishing events")
+	}
+	logbeat.eventsProcessed.Add(float64(len(events)))
+
+	return nil
+}
+
+func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
+	events := vpcFlowLog{}
+
+	s := s3.New(session.New(logbeat.awsConfig))
+	q := s3.GetObjectInput{
+		Bucket: aws.String(m.S3.Bucket.Name),
+		Key:	aws.String(m.S3.Object.Key),
+	}
+	o, err := s.GetObject(&q)
+	if err != nil {
+		return events, err
+	}
+
+	gunzip, err := gzip.NewReader(o.Body)
+	if err != nil {
+		return events, fmt.Errorf("Error gunzipping %v", q)
+	}
+
+	logs := csv.NewReader(gunzip)
+	logs.Comma = ' '
+
+	headerRow, err := logs.Read()
+	if err == io.EOF {
+		return events, fmt.Errorf("Downloaded logfile doesn't have a first header row.")
+	} else if err != nil {
+		logp.Err("Unknown error reading header row from logfile: %v", err)
+		panic(err) // or handle it another way
+	}
+
+	logbeat.createFieldMap(headerRow[:]...)
+
+	logp.Info("Reading rows into VPCFlogLog events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+	for {
+		row, err := logs.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			logp.Err("Unknown error reading row from logfile: %v", err)
+			panic(err) // or handle it another way
+		}
+
+		for index, value := range row {
+			if (value == "-") {
+				row[index] = ""
+			}
+		}
+
+		var event vpcFlowLogEvent
+
+		/* A lot of the logic here is to mimic as much as possible the structure
+		   of netflow data written into ELK by the netflow Logstash codec. AWS-
+		   specific fields are all going to be in a sub-structure called
+		   awsDetails */
+		event.EventTime = m.EventTime
+		version := logbeat.getRowIndexValue("version")
+		if (version >= 0) { event.AwsDetails.Version = row[version] }
+		accountid := logbeat.getRowIndexValue("account-id")
+		if (accountid >= 0) { event.AwsDetails.AccountId, _ = strconv.ParseInt(row[accountid], 10, 64) }
+		interfaceid := logbeat.getRowIndexValue("interface-id")
+		if (interfaceid >= 0) { event.AwsDetails.InterfaceId = row[interfaceid] }
+		ftype := logbeat.getRowIndexValue("type")
+		if (ftype >= 0) { event.AwsDetails.Type = row[ftype] }
+		srcaddr := logbeat.getRowIndexValue("srcaddr")
+		dstaddr := logbeat.getRowIndexValue("dstaddr")
+		if (event.AwsDetails.Type == "IPv4") {
+			if (srcaddr >= 0) { event.Ipv4SrcAddr = row[srcaddr] }
+			if (dstaddr >= 0) { event.Ipv4DstAddr = row[dstaddr] }
+		} else if (event.AwsDetails.Type == "IPv6") {
+			if (srcaddr >= 0) { event.Ipv6SrcAddr = row[srcaddr] }
+			if (dstaddr >= 0) { event.Ipv6DstAddr = row[dstaddr] }
+		}
+		srcport := logbeat.getRowIndexValue("srcport")
+		if (srcport >= 0) { event.L4SrcPort, _ = strconv.ParseInt(row[srcport], 10, 64) }
+		dstport := logbeat.getRowIndexValue("dstport")
+		if (dstport >= 0) { event.L4DstPort, _ = strconv.ParseInt(row[dstport], 10, 64) }
+		protocol := logbeat.getRowIndexValue("protocol")
+		if (protocol >= 0) { event.Protocol, _ = strconv.ParseInt(row[protocol], 10, 64) }
+		packets := logbeat.getRowIndexValue("packets")
+		if (packets >= 0) { event.InPkts, _ = strconv.ParseInt(row[packets], 10, 64) }
+		bytes := logbeat.getRowIndexValue("bytes")
+		if (bytes >= 0) { event.InBytes, _ = strconv.ParseInt(row[bytes], 10, 64) }
+		start := logbeat.getRowIndexValue("start")
+		if (start >= 0) { event.AwsDetails.Start, _ = strconv.ParseInt(row[start], 10, 64) }
+		end := logbeat.getRowIndexValue("end")
+		if (end >= 0) { event.AwsDetails.End, _ = strconv.ParseInt(row[end], 10, 64) }
+		action := logbeat.getRowIndexValue("action")
+		if (action >= 0) { event.AwsDetails.Action = row[action] }
+		logstatus := logbeat.getRowIndexValue("log-status")
+		if (logstatus >= 0) { event.AwsDetails.LogStatus = row[logstatus] }
+		vpcid := logbeat.getRowIndexValue("vpc-id")
+		if (vpcid >= 0) { event.AwsDetails.VpcId = row[vpcid] }
+		subnetid := logbeat.getRowIndexValue("subnet-id")
+		if (subnetid >= 0) { event.AwsDetails.SubnetId = row[subnetid] }
+		instanceid := logbeat.getRowIndexValue("instance-id")
+		if (instanceid >= 0) { event.AwsDetails.InstanceId = row[instanceid] }
+		tcpflags := logbeat.getRowIndexValue("tcp-flags")
+		if (tcpflags >= 0) {
+			flags, _ := strconv.ParseInt(row[tcpflags], 10, 64)
+			if ((flags & 1) == 1) {
+				event.AwsDetails.TcpFlags = append(event.AwsDetails.TcpFlags, "FIN")
+			}
+			if ((flags & 2) == 2) {
+				event.AwsDetails.TcpFlags = append(event.AwsDetails.TcpFlags, "SYN")
+			}
+			if ((flags & 18) == 18) {
+				event.AwsDetails.TcpFlags = append(event.AwsDetails.TcpFlags, "SYN-ACK")
+			}
+			if ((flags & 4) == 4) {
+				event.AwsDetails.TcpFlags = append(event.AwsDetails.TcpFlags, "RST")
+			}
+		}
+		pktsrcaddr := logbeat.getRowIndexValue("pkt-srcaddr")
+		if (pktsrcaddr >= 0) { event.AwsDetails.PktSrcAddr = row[pktsrcaddr] }
+		pktdstaddr := logbeat.getRowIndexValue("pkt-dstaddr")
+		if (pktdstaddr >= 0) { event.AwsDetails.PktDstAddr = row[pktdstaddr] }
+		region := logbeat.getRowIndexValue("region")
+		if (region >= 0) { event.AwsDetails.Region = row[region] }
+		azid := logbeat.getRowIndexValue("az-id")
+		if (azid >= 0) { event.AwsDetails.AzId = row[azid] }
+		sublocationtype := logbeat.getRowIndexValue("sublocation-type")
+		if (sublocationtype >= 0) { event.AwsDetails.SublocationType = row[sublocationtype] }
+		sublocationid := logbeat.getRowIndexValue("sublocation-id")
+		if (sublocationid >= 0) { event.AwsDetails.SublocationId = row[sublocationid] }
+		pktsrcawsservice := logbeat.getRowIndexValue("pkt-src-aws-service")
+		if (pktsrcawsservice >= 0) { event.AwsDetails.PktSrcAwsService = row[pktsrcawsservice] }
+		pktdstawsservice := logbeat.getRowIndexValue("pkt-dst-aws-service")
+		if (pktdstawsservice >= 0) { event.AwsDetails.PktDstAwsService = row[pktdstawsservice] }
+		flowdirection := logbeat.getRowIndexValue("flow-direction")
+		event.AwsDetails.FlowDirection = row[flowdirection]
+		if (flowdirection >= 0) {
+			if (row[flowdirection] == "ingress") {
+				event.Direction = 0
+			} else if (row[flowdirection] == "egress") {
+				event.Direction = 1
+			}
+		}
+		trafficpath := logbeat.getRowIndexValue("traffic-path")
+		if (trafficpath >= 0) {
+			switch row[trafficpath] {
+			case "1":
+				event.AwsDetails.TrafficPath = "1 — Through another resource in the same VPC"
+			case "2":
+				event.AwsDetails.TrafficPath = "2 — Through an internet gateway or a gateway VPC endpoint"
+			case "3":
+				event.AwsDetails.TrafficPath = "3 — Through a virtual private gateway"
+			case "4":
+				event.AwsDetails.TrafficPath = "4 — Through an intra-region VPC peering connection"
+			case "5":
+				event.AwsDetails.TrafficPath = "5 — Through an inter-region VPC peering connection"
+			case "6":
+				event.AwsDetails.TrafficPath = "6 — Through a local gateway"
+			case "7":
+				event.AwsDetails.TrafficPath = "7 — Through a gateway VPC endpoint (Nitro-based instances only)"
+			case "8":
+				event.AwsDetails.TrafficPath = "8 — Through an internet gateway (Nitro-based instances only)"
+			}
+		}
+
+		logp.Debug("vpcflowlogbeat", "created event, %v", event)
+		events.Records = append(events.Records, event)
+	}
+	logp.Info("Finished reading rows into VPCFlowLog events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+
+	return events, nil
+}
+
+func (logbeat *S3AwsLogBeat) getRowIndexValue(field string) (int) {
+	var returnValue int = -1
+	if index, ok := logbeat.csvFields[field]; ok {
+		returnValue = index
+	}
+	logp.Debug("vpcflowlogbeat", "getRowIndexValue %v yields %v", field, returnValue)
+	return returnValue
+}
+
+func (logbeat *S3AwsLogBeat) createFieldMap(headerRow ...string) {
+	logbeat.csvFields = make(map[string]int)
+	for i, h := range headerRow {
+		logbeat.csvFields[h] = i
+	}
+	logp.Debug("vpcflowlogbeat", "CSV Fields Parsed: %v", logbeat.csvFields)
+}

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -140,6 +140,8 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
+	logbeat.awsS3Config = logbeat.awsS3Config.WithRegion(m.AwsRegion)
+
 	s := s3.New(session.New(logbeat.awsConfig))
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),

--- a/etc/beat.yml
+++ b/etc/beat.yml
@@ -22,3 +22,6 @@ input:
     # this is useful for debug purposes.
     # default: false
     no_purge: true
+
+    # FIXME: cloudtrail, vpcflowlog (and future plans for guardduty and others)
+    log_mode: vpcflowlog

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -134,3 +134,142 @@ cloudtrail:
           description: >
             Represents the account ID that received this event.
     
+vpcflowlog:
+  type: group
+  description: >
+    Contains information about a VPC Flow Log entry
+  fields:
+    - name: ip_version
+      description: >
+        The type of traffic. The possible values are: IPv4, IPv6, and EFA. For more information about the Elastic Fabric Adapter (EFA), see Elastic Fabric Adapter (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html).
+    - name: netflow
+      type: group
+      description: >
+          Contains VPC Flow Logs.
+      fields:
+        - name: ipv4_src_addr
+          type: ip
+          description: >
+            The source address for incoming traffic, or the IPv4 or IPv6 address of the network interface for outgoing traffic on the network interface. The IPv4 address of the network interface is always its private IPv4 address. See also pkt-srcaddr.
+        - name: ipv6_src_addr
+          type: ip
+          description: >
+            The destination address for outgoing traffic, or the IPv4 or IPv6 address of the network interface for incoming traffic on the network interface. The IPv4 address of the network interface is always its private IPv4 address. See also pkt-dstaddr.
+        - name: l4_src_port
+          type: integer
+          description: >
+            The source port of the traffic.
+        - name: l4_dst_port
+          type: integer
+          description: >
+            The destination port of the traffic.
+        - name: protocol
+          type: integer
+          description: >
+            The IANA protocol number of the traffic. For more information, see http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml.
+        - name: in_pkts
+          type: integer
+          description: >
+            The number of packets transferred during the flow.
+        - name: in_bytes
+          type: integer
+          description: >
+            The number of bytes transferred during the flow.
+    - name: awsDetails
+      type: group
+      description: >
+          Contains VPC Flow Logs.
+      fields:
+        - name: version
+          description: >
+            The VPC Flow Logs version. If you use the default format, the version is 2. If you use a custom format, the version is the highest version among the specified fields. For example, if you specify only fields from version 2, the version is 2. If you specify a mixture of fields from versions 2, 3, and 4, the version is 4.
+        - name: account_id
+          type: integer
+          description: >
+            The AWS account ID of the owner of the source network interface for which traffic is recorded. If the network interface is created by an AWS service, for example when creating a VPC endpoint or Network Load Balancer, the record may display unknown for this field.
+        - name: interface_id
+          description: >
+            The ID of the network interfaces for which the traffic is recorded.
+        - name: start
+          type: date
+          format: "strict_date_optional_time||epoch_second"
+          description: >
+            The time, in Unix seconds, when the first packet of the flow was received within the aggregation interval. This might be up to 60 seconds after the packet was transmitted or received on the network interface.
+        - name: end
+          type: date
+          format: "strict_date_optional_time||epoch_second"
+          description: >
+            The time, in Unix seconds, when the last packet of the flow was received within the aggregation interval. This might be up to 60 seconds after the packet was transmitted or received on the network interface.
+        - name: action
+          description: >
+            The action that is associated with the traffic:
+              - ACCEPT — The recorded traffic was permitted by the security groups and network ACLs.
+              - REJECT — The recorded traffic was not permitted by the security groups or network ACLs.
+        - name: log_status
+          description: >
+            The logging status of the flow log:
+              - OK — Data is logging normally to the chosen destinations.
+              - NODATA — There was no network traffic to or from the network interface during the aggregation interval.
+              - SKIPDATA — Some flow log records were skipped during the aggregation interval. This may be because of an internal capacity constraint, or an internal error.
+        - name: vpc_id
+          description: >
+            The ID of the VPC that contains the network interface for which the traffic is recorded.
+        - name: subnet_id
+          description: >
+            The ID of the subnet that contains the network interface for which the traffic is recorded.
+        - name: instance_id
+          description: >
+            The ID of the instance that's associated with network interface for which the traffic is recorded, if the instance is owned by you. Returns a '-' symbol for a requester-managed network interface; for example, the network interface for a NAT gateway.
+        - name: tcp_flags
+          description: >
+            The bitmask value for the following TCP flags:
+              - SYN — 2
+              - SYN-ACK — 18
+              - FIN — 1
+              - RST — 4
+            ACK is reported only when it's accompanied with SYN.
+            TCP flags can be OR-ed during the aggregation interval. For short connections, the flags might be set on the same line in the flow log record, for example, 19 for SYN-ACK and FIN, and 3 for SYN and FIN. For an example, see TCP flag sequence.
+        - name: type
+          type: string
+          description: >
+            The type of traffic. The possible values are: IPv4, IPv6, and EFA. For more information about the Elastic Fabric Adapter (EFA), see Elastic Fabric Adapter (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html).
+        - name: pkt_srcaddr
+          type: ip
+          description: >
+            The packet-level (original) source IP address of the traffic. Use this field with the srcaddr field to distinguish between the IP address of an intermediate layer through which traffic flows, and the original source IP address of the traffic. For example, when traffic flows through a network interface for a NAT gateway, or where the IP address of a pod in Amazon EKS is different from the IP address of the network interface of the instance node on which the pod is running (for communication within a VPC).
+        - name: pkt_dstaddr
+          type: ip
+          description: >
+            The packet-level (original) destination IP address for the traffic. Use this field with the dstaddr field to distinguish between the IP address of an intermediate layer through which traffic flows, and the final destination IP address of the traffic. For example, when traffic flows through a network interface for a NAT gateway, or where the IP address of a pod in Amazon EKS is different from the IP address of the network interface of the instance node on which the pod is running (for communication within a VPC).
+        - name: region
+          description: >
+            The Region that contains the network interface for which traffic is recorded.
+        - name: az_id
+          description: >
+            The ID of the Availability Zone that contains the network interface for which traffic is recorded. If the traffic is from a sublocation, the record displays a '-' symbol for this field.
+        - name: sublocation_type
+          description: >
+            The type of sublocation that's returned in the sublocation-id field. The possible values are: wavelength | outpost | localzone. If the traffic is not from a sublocation, the record displays a '-' symbol for this field. 
+        - name: sublocation_id
+          description: >
+            The ID of the sublocation that contains the network interface for which traffic is recorded. If the traffic is not from a sublocation, the record displays a '-' symbol for this field.
+        - name: pkt_src_aws_service
+          description: >
+            The name of the subset of IP address ranges for the pkt-srcaddr field, if the source IP address is for an AWS service. The possible values are: AMAZON | AMAZON_APPFLOW | AMAZON_CONNECT | API_GATEWAY | CHIME_MEETINGS | CHIME_VOICECONNECTOR | CLOUD9 | CLOUDFRONT | CODEBUILD | DYNAMODB | EC2 | EC2_INSTANCE_CONNECT | GLOBALACCELERATOR | KINESIS_VIDEO_STREAMS | ROUTE53 | ROUTE53_HEALTHCHECKS | S3 | WORKSPACES_GATEWAYS.
+        - name: pkt_dst_aws_service
+          description: >
+            The name of the subset of IP address ranges for the pkt-dstaddr field, if the destination IP address is for an AWS service. For a list of possible values, see the pkt-src-aws-service field.
+        - name: flow_direction
+          description: >
+            The direction of the flow with respect to the interface where traffic is captured. The possible values are: ingress | egress.
+        - name: traffic_path
+          description: >
+            The path that egress traffic takes to the destination. To determine whether the traffic is egress traffic, check the flow-direction field. The possible values are as follows. If none of the values apply, the field is set to -.
+              1 — Through another resource in the same VPC
+              2 — Through an internet gateway or a gateway VPC endpoint
+              3 — Through a virtual private gateway
+              4 — Through an intra-region VPC peering connection
+              5 — Through an inter-region VPC peering connection
+              6 — Through a local gateway
+              7 — Through a gateway VPC endpoint (Nitro-based instances only)
+              8 — Through an internet gateway (Nitro-based instances only)

--- a/s3awslogbeat.yml
+++ b/s3awslogbeat.yml
@@ -24,7 +24,7 @@ input:
     no_purge: true
 
     # FIXME: Future plans to support vpcflowlog and guardduty (and others)
-    log_mode: cloudtrail
+    log_mode: vpcflowlog
 
 ###############################################################################
 metrics:


### PR DESCRIPTION
This adds VPC Flow log ingress functions to the beat. This varies from the now deprecated vpcflowlogbeat branch because it's unified code with the cloudtrail logs ingress, and this is now also built on the base with Prometheus metrics.