### PR TITLE
Add GuardDuty support to s3awslogbeat

### DIFF
--- a/beater/cloudtrail_functions.go
+++ b/beater/cloudtrail_functions.go
@@ -137,7 +137,7 @@ func (logbeat *S3AwsLogBeat) readCloudTrailLogfile(m sqsNotificationMessage) (cl
 	}
 
 	if err := json.Unmarshal(b, &events); err != nil {
-		return events, fmt.Errorf("Error unmarshaling cloutrail JSON: %s", err.Error())
+		return events, fmt.Errorf("Error unmarshaling cloudtrail JSON: %s", err.Error())
 	}
 
 	return events, nil

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -141,10 +141,14 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 		jsonLine, err := b.ReadString('\n')
 
 		if err := json.Unmarshal([]byte(jsonLine), &event); err != nil {
-			logp.Info("Error unmarshaling guardduty JSON: %s", err.Error())
-			logp.Info("%+v\n", jsonLine)
-			panic(err)
-			continue
+			if len(jsonLine) == 0 && err == io.EOF {
+				// last line will be empty with newline
+				logp.Info("Last line of logfile is empty: %+v", err)
+				break
+			} else {
+				logp.Info("Error unmarshaling guardduty JSON: %+v", err)
+				logp.Info("%+v\n", jsonLine)
+			}
 		}
 
 		logp.Debug("s3awslogbeat", "created event, %v", event)

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"io"
 	// "compress/gzip"
+	"bufio"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -126,17 +127,15 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 		return events, err
 	}
 
-	b := make([]byte, 8)
+	b := bufio.NewReader(o.Body)
 	for {
-		n, err := o.Body.Read(b)
-		fmt.Printf("n = %v err = %v b = %v\n", n, err, b)
-		fmt.Printf("b[:n] = %q\n", b[:n])
+		string, err := b.ReadString('\n')
+		fmt.Printf("err = %v string = %v\n", err, string)
 		if err == io.EOF {
 			break
 		}
-		panic("did a thing")
 	}
-
+	panic("did a thing")
 /*	gunzip, err := gzip.NewReader(o.Body)
 	if err != nil {
 		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -139,6 +139,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 				break
 			} else {
 				logp.Info("Error unmarshaling guardduty JSON: %+v", err)
+				logp.Info("START%+vEND", jsonLine)
 				logp.Info("%+v\n", jsonLine)
 			}
 		}

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -120,6 +120,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),
 		Key:	aws.String(m.S3.Object.Key),
+		SSECustomerAlgorithm: aws.String("AES256"),
 		SSECustomerKey:	aws.String("arn:aws:kms:us-east-1:580760757891:key/f4261c50-b5fd-47f2-987b-5ca9231d44af"),
 	}
 	o, err := s.GetObject(&q)

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -120,6 +120,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),
 		Key:	aws.String(m.S3.Object.Key),
+		SSECustomerKey:	aws.String("arn:aws:kms:us-east-1:580760757891:key/f4261c50-b5fd-47f2-987b-5ca9231d44af"),
 	}
 	o, err := s.GetObject(&q)
 	if err != nil {
@@ -130,7 +131,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	if err != nil {
 		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)
 		logp.Err("Error gunzipping %v: %+v", m.S3.Object.Key, err)
-		logp.Err("Content: %+v", o.Body)
+		logp.Err("Content: %+v", o)
 		panic(err) // or handle it another way
 	}
 

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -130,6 +130,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	if err != nil {
 		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)
 		logp.Err("Error gunzipping %v: %+v", m.S3.Object.Key, err)
+		logp.Err("Content: %+v", o.Body)
 		panic(err) // or handle it another way
 	}
 

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -128,7 +128,9 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 
 	gunzip, err := gzip.NewReader(o.Body)
 	if err != nil {
-		return events, fmt.Errorf("Error gunzipping %v: %v", q.Key, err)
+		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)
+		logp.Err("Error gunzipping %v: %+v", m.S3.Object.Key, err)
+		panic(err) // or handle it another way
 	}
 
 	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -120,8 +120,6 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	q := s3.GetObjectInput{
 		Bucket: aws.String(m.S3.Bucket.Name),
 		Key:	aws.String(m.S3.Object.Key),
-		SSECustomerAlgorithm: aws.String("AES256"),
-		SSECustomerKey:	aws.String("arn:aws:kms:us-east-1:580760757891:key/f4261c50-b5fd-47f2-987b-5ca9231d44af"),
 	}
 	o, err := s.GetObject(&q)
 	if err != nil {

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -1,0 +1,157 @@
+package beater
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"io"
+	"compress/gzip"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/publisher"
+)
+
+// data struct matching the defined fields of a GuardDuty Event as
+// Unable to find a full JSON schema spec for this
+type guarddutyLog struct {
+	Records []guarddutyEvent
+}
+type guarddutyEvent struct {
+	AccountID			string					`json:"accountId"`
+	Region				string					`json:"region"`
+	Partition			string					`json:"partition"`
+	Arn					string					`json:"arn"`
+	Type				string					`json:"type"`
+	Resource			map[string]interface{}	`json:"resource"`
+	Service				map[string]interface{}	`json:"service"`
+	Severity			string					`json:"severity"`
+	CreatedAt			string					`json:"createdAt"`
+	UpdatedAt			string					`json:"updatedAt"`
+	Title				string					`json:"title"`
+	Description			string					`json:"description"`
+}
+
+type guarddutyEventFieldFunction func(e *guarddutyEvent) interface{}
+
+var guarddutyEventField = map[string]guarddutyEventFieldFunction{
+    "accountID": func(e *guarddutyEvent) interface{}          { return e.AccountID },
+    "region": func(e *guarddutyEvent) interface{}       { return e.Region },
+    "partition": func(e *guarddutyEvent) interface{}        { return e.Partition },
+    "arn": func(e *guarddutyEvent) interface{}       { return e.Arn },
+    "type": func(e *guarddutyEvent) interface{}          { return e.Type },
+    "resource": func(e *guarddutyEvent) interface{}          { return e.Resource },
+    "service": func(e *guarddutyEvent) interface{}    { return e.Service },
+    "severity": func(e *guarddutyEvent) interface{}          { return e.Severity },
+    "createdAt": func(e *guarddutyEvent) interface{}          { return e.CreatedAt },
+    "updatedAt": func(e *guarddutyEvent) interface{}       { return e.UpdatedAt },
+    "title": func(e *guarddutyEvent) interface{}  { return e.Title },
+    "description": func(e *guarddutyEvent) interface{}          { return e.Description },
+}
+
+func guarddutyMatchPattern(event guarddutyEvent, field string, search string) bool {
+	if strings.Contains(field, ".") {
+		parts := strings.SplitN(field, ".", 2)
+		logp.Debug("s3awslogbeat", "need to find %s in event.%s[\"%s\"] (ARN: %+v)\n", search, parts[0], parts[1], event.Arn)
+		if mapToSearch := guarddutyEventField[parts[0]](&event); mapToSearch != nil {
+			logp.Debug("s3awslogbeat", "mapToSearch: %+v\n", mapToSearch)
+			if fieldToSearch := mapToSearch.(map[string]interface{})[parts[1]]; fieldToSearch != nil {
+				logp.Debug("s3awslogbeat", "fieldToSearch: %+v\n", fieldToSearch)
+				return strings.Contains(fieldToSearch.(string), search)
+			}
+		}
+	} else {
+		logp.Debug("s3awslogbeat", "need to find %s in event.%s (ARN: %+v)\n", search, field, event.Arn)
+		if fieldToSearch := guarddutyEventField[field](&event); fieldToSearch != nil {
+			return strings.Contains(fieldToSearch.(string), search)
+		}
+	}
+	return false
+}
+
+func (logbeat *S3AwsLogBeat) publishGuardDutyEvents(logs guarddutyLog) error {
+	if len(logs.Records) < 1 {
+		return nil
+	}
+
+	events := make([]common.MapStr, 0, len(logs.Records))
+
+	for _, logEvent := range logs.Records {
+		timestamp, err := time.Parse(logTimeFormat, logEvent.CreatedAt)
+
+		if err != nil {
+			logp.Err("Unable to parse CreatedAt : %s", logEvent.CreatedAt)
+		}
+
+		for _, counter := range logbeat.customCounterMetrics {
+			if guarddutyMatchPattern(logEvent, counter.Field, counter.Match) {
+				counter.Counter.Inc()
+			}
+		}
+
+		le := common.MapStr{
+			"@timestamp": common.Time(timestamp),
+			"type":	   "GuardDuty",
+			"guardduty": logEvent,
+		}
+
+		events = append(events, le)
+	}
+	if !logbeat.events.PublishEvents(events, publisher.Sync, publisher.Guaranteed) {
+		logbeat.eventsProcessedErrors.Add(float64(len(events)))
+		return fmt.Errorf("Error publishing events")
+	}
+	logbeat.eventsProcessed.Add(float64(len(events)))
+
+	return nil
+}
+
+func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog, error) {
+	events := guarddutyLog{}
+
+	logbeat.awsS3Config = logbeat.awsS3Config.WithRegion(m.AwsRegion)
+
+	s := s3.New(session.New(logbeat.awsS3Config))
+	q := s3.GetObjectInput{
+		Bucket: aws.String(m.S3.Bucket.Name),
+		Key:	aws.String(m.S3.Object.Key),
+	}
+	o, err := s.GetObject(&q)
+	if err != nil {
+		return events, err
+	}
+
+	gunzip, err := gzip.NewReader(o.Body)
+	if err != nil {
+		return events, fmt.Errorf("Error gunzipping %v", q)
+	}
+
+	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+	for {
+		var row []byte
+		_, err := gunzip.Read(row)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			logp.Err("Unknown error reading row from logfile: %v", err)
+			panic(err) // or handle it another way
+		}
+
+		var event guarddutyEvent
+
+		if err := json.Unmarshal([]byte(row), &events); err != nil {
+			return events, fmt.Errorf("Error unmarshaling guardduty JSON: %s", err.Error())
+		}
+
+		logp.Debug("s3awslogbeat", "created event, %v", event)
+		events.Records = append(events.Records, event)
+	}
+	logp.Info("Finished reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+
+	return events, nil
+}

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -142,6 +142,8 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 
 		if err := json.Unmarshal([]byte(jsonLine), &event); err != nil {
 			logp.Info("Error unmarshaling guardduty JSON: %s", err.Error())
+			logp.Info("%+v\n", jsonLine)
+			panic(err)
 			continue
 		}
 

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -145,7 +145,6 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 				break
 			} else {
 				logp.Info("Error unmarshaling guardduty JSON: %+v", err)
-				logp.Info("START%+vEND %d", jsonLine, len(jsonLine))
 				logp.Info("%+v\n", jsonLine)
 			}
 		}
@@ -153,10 +152,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 		logp.Debug("s3awslogbeat", "created event, %v", event)
 		events.Records = append(events.Records, event)
 
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			logp.Err("Unknown error reading row from logfile: %v", err)
+		if lastLine {
 			break
 		}
 	}

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -1,12 +1,12 @@
 package beater
 
 import (
-	"encoding/json"
+/*	"encoding/json"*/
 	"fmt"
 	"strings"
 	"time"
 	"io"
-	"compress/gzip"
+	// "compress/gzip"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -126,15 +126,26 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 		return events, err
 	}
 
-	gunzip, err := gzip.NewReader(o.Body)
+	b := make([]byte, 8)
+	for {
+		n, err := o.Body.Read(b)
+		fmt.Printf("n = %v err = %v b = %v\n", n, err, b)
+		fmt.Printf("b[:n] = %q\n", b[:n])
+		if err == io.EOF {
+			break
+		}
+		panic("did a thing")
+	}
+
+/*	gunzip, err := gzip.NewReader(o.Body)
 	if err != nil {
 		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)
 		logp.Err("Error gunzipping %v: %+v", m.S3.Object.Key, err)
 		logp.Err("Content: %+v", o)
 		panic(err) // or handle it another way
-	}
+	}*/
 
-	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+/*	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
 	for {
 		var row []byte
 		_, err := gunzip.Read(row)
@@ -154,7 +165,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 		logp.Debug("s3awslogbeat", "created event, %v", event)
 		events.Records = append(events.Records, event)
 	}
-	logp.Info("Finished reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+	logp.Info("Finished reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)*/
 
 	return events, nil
 }

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -128,7 +128,7 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 
 	gunzip, err := gzip.NewReader(o.Body)
 	if err != nil {
-		return events, fmt.Errorf("Error gunzipping %v", q)
+		return events, fmt.Errorf("Error gunzipping %v: %v", q.Key, err)
 	}
 
 	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -1,12 +1,11 @@
 package beater
 
 import (
-/*	"encoding/json"*/
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 	"io"
-	// "compress/gzip"
 	"bufio"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -135,36 +134,28 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 			break
 		}
 	}
-	panic("did a thing")
-/*	gunzip, err := gzip.NewReader(o.Body)
-	if err != nil {
-		//return events, fmt.Errorf("Error gunzipping %v: %+v", m.S3.Object.Key, err)
-		logp.Err("Error gunzipping %v: %+v", m.S3.Object.Key, err)
-		logp.Err("Content: %+v", o)
-		panic(err) // or handle it another way
-	}*/
 
-/*	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
+	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
 	for {
-		var row []byte
-		_, err := gunzip.Read(row)
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			logp.Err("Unknown error reading row from logfile: %v", err)
-			panic(err) // or handle it another way
-		}
-
 		var event guarddutyEvent
+		jsonLine, err := b.ReadString('\n')
 
-		if err := json.Unmarshal([]byte(row), &events); err != nil {
-			return events, fmt.Errorf("Error unmarshaling guardduty JSON: %s", err.Error())
+		if err := json.Unmarshal([]byte(jsonLine), &event); err != nil {
+			logp.Info("Error unmarshaling guardduty JSON: %s", err.Error())
+			continue
 		}
 
 		logp.Debug("s3awslogbeat", "created event, %v", event)
 		events.Records = append(events.Records, event)
+
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			logp.Err("Unknown error reading row from logfile: %v", err)
+			break
+		}
 	}
-	logp.Info("Finished reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)*/
+	logp.Info("Finished reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
 
 	return events, nil
 }

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -127,14 +127,6 @@ func (logbeat *S3AwsLogBeat) readGuardDutyLogfile(m messageObject) (guarddutyLog
 	}
 
 	b := bufio.NewReader(o.Body)
-	for {
-		string, err := b.ReadString('\n')
-		fmt.Printf("err = %v string = %v\n", err, string)
-		if err == io.EOF {
-			break
-		}
-	}
-
 	logp.Info("Reading rows into GuardDuty events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
 	for {
 		var event guarddutyEvent

--- a/beater/guardduty_functions.go
+++ b/beater/guardduty_functions.go
@@ -30,7 +30,7 @@ type guarddutyEvent struct {
 	Type				string					`json:"type"`
 	Resource			map[string]interface{}	`json:"resource"`
 	Service				map[string]interface{}	`json:"service"`
-	Severity			string					`json:"severity"`
+	Severity			int64					`json:"severity"`
 	CreatedAt			string					`json:"createdAt"`
 	UpdatedAt			string					`json:"updatedAt"`
 	Title				string					`json:"title"`

--- a/beater/s3awslogbeat.go
+++ b/beater/s3awslogbeat.go
@@ -72,7 +72,7 @@ var cmdLineArgs CmdLineArgs
 type sqsMessage struct {
 	Type				string
 	Subject				string	`json:",omitempty"`
-	MessageID			string
+	MessageId			string
 	TopicArn			string
 	Message				string
 	Timestamp			string
@@ -88,7 +88,7 @@ type sqsNotificationMessage struct {
 	S3Bucket		string		`json:"s3Bucket,omitempty"`
 	S3ObjectKey		[]string	`json:"s3ObjectKey,omitempty"`
 	Records         []messageObject `json:"Records,omitempty"`
-	MessageID		string		`json:",omitempty"`
+	MessageId		string		`json:",omitempty"`
 	ReceiptHandle	string		`json:",omitempty"`
 }
 
@@ -318,14 +318,14 @@ func (logbeat *S3AwsLogBeat) runQueue() error {
 				lf, err := logbeat.readCloudTrailLogfile(m)
 				if err != nil {
 					logbeat.filesProcessedErrors.Inc()
-					logp.Err("Error reading log file [messageID: %s]: %s", m.MessageId, err)
+					logp.Err("Error reading log file [MessageId: %s]: %s", m.MessageId, err)
 					continue
 				}
 				logbeat.filesProcessed.Inc()
 				
 				logp.Info("Publishing events from : s3://%s/%s", m.S3Bucket, m.S3ObjectKey)
 				if err := logbeat.publishCloudTrailEvents(lf); err != nil {
-					logp.Err("Error publishing events [messageID: %s]: %s", m.MessageId, err)
+					logp.Err("Error publishing events [MessageId: %s]: %s", m.MessageId, err)
 					continue
 				}
 			case "vpcflowlog":
@@ -333,13 +333,13 @@ func (logbeat *S3AwsLogBeat) runQueue() error {
 					logp.Info("Downloading and processing log file: s3://%s/%s", r.S3.Bucket.Name, r.S3.Object.Key)
 					lf, err := logbeat.readVpcFlowLogfile(r)
 					if err != nil {
-						logp.Err("Error reading log file [messageID: %s]: %s", m.MessageId, err)
+						logp.Err("Error reading log file [MessageId: %s]: %s", m.MessageId, err)
 						continue
 					}
 					logbeat.filesProcessed.Inc()
 
 					if err := logbeat.publishVpcFlowLogEvents(lf); err != nil {
-						logp.Err("Error publishing events [messageID: %s]: %s", m.MessageId, err)
+						logp.Err("Error publishing events [MessageId: %s]: %s", m.MessageId, err)
 						continue
 					}
 				}
@@ -348,13 +348,13 @@ func (logbeat *S3AwsLogBeat) runQueue() error {
 					logp.Info("Downloading and processing log file: s3://%s/%s", r.S3.Bucket.Name, r.S3.Object.Key)
 					lf, err := logbeat.readGuardDutyLogfile(r)
 					if err != nil {
-						logp.Err("Error reading log file [messageID: %s]: %s", m.MessageId, err)
+						logp.Err("Error reading log file [MessageId: %s]: %s", m.MessageId, err)
 						continue
 					}
 					logbeat.filesProcessed.Inc()
 
 					if err := logbeat.publishGuardDutyEvents(lf); err != nil {
-						logp.Err("Error publishing events [messageID: %s]: %s", m.MessageId, err)
+						logp.Err("Error publishing events [MessageId: %s]: %s", m.MessageId, err)
 						continue
 					}
 				}
@@ -364,7 +364,7 @@ func (logbeat *S3AwsLogBeat) runQueue() error {
 
 			if !logbeat.noPurge {
 				if err := logbeat.deleteMessage(m); err != nil {
-					logp.Err("Error deleting processed SQS event [messageID: %s]: %s", m.MessageId, err)
+					logp.Err("Error deleting processed SQS event [MessageId: %s]: %s", m.MessageId, err)
 				}
 			}
 		}
@@ -457,7 +457,7 @@ func (logbeat *S3AwsLogBeat) fetchMessages() ([]sqsNotificationMessage, error) {
 	for _, e := range resp.Messages {
 		tmsg := sqsMessage{}
 		event := sqsNotificationMessage{}
-		event.MessageID = tmsg.MessageID
+		event.MessageId = tmsg.MessageId
 		event.ReceiptHandle = *e.ReceiptHandle
 
 		if err := json.Unmarshal([]byte(*e.Body), &tmsg); err != nil {
@@ -469,7 +469,7 @@ func (logbeat *S3AwsLogBeat) fetchMessages() ([]sqsNotificationMessage, error) {
 			if tmsg.Message == "CloudTrail validation message." {
 				if !logbeat.noPurge {
 					if err := logbeat.deleteMessage(event); err != nil {
-						return nil, fmt.Errorf("Error deleting 'validation message' [id: %s]: %s", tmsg.MessageID, err)
+						return nil, fmt.Errorf("Error deleting 'validation message' [id: %s]: %s", tmsg.MessageId, err)
 					}
 				}
 				continue

--- a/beater/s3awslogbeat.go
+++ b/beater/s3awslogbeat.go
@@ -457,12 +457,13 @@ func (logbeat *S3AwsLogBeat) fetchMessages() ([]sqsNotificationMessage, error) {
 	for _, e := range resp.Messages {
 		tmsg := sqsMessage{}
 		event := sqsNotificationMessage{}
-		event.MessageId = tmsg.MessageId
-		event.ReceiptHandle = *e.ReceiptHandle
 
 		if err := json.Unmarshal([]byte(*e.Body), &tmsg); err != nil {
 			return nil, fmt.Errorf("SQS message JSON parse error [id: %s]: %s", *e.MessageId, err.Error())
 		}
+
+		event.MessageId = tmsg.MessageId
+		event.ReceiptHandle = *e.ReceiptHandle
 
 		switch logbeat.logMode {
 		case "cloudtrail":

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -138,7 +138,7 @@ func (logbeat *S3AwsLogBeat) publishVpcFlowLogEvents(logs vpcFlowLog) error {
 	return nil
 }
 
-func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m vpcFlowLogMessageObject) (vpcFlowLog, error) {
+func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m messageObject) (vpcFlowLog, error) {
 	events := vpcFlowLog{}
 
 	logbeat.awsS3Config = logbeat.awsS3Config.WithRegion(m.AwsRegion)

--- a/beater/vpcflowlog_functions.go
+++ b/beater/vpcflowlog_functions.go
@@ -298,7 +298,7 @@ func (logbeat *S3AwsLogBeat) readVpcFlowLogfile(m messageObject) (vpcFlowLog, er
 			}
 		}
 
-		logp.Debug("vpcflowlogbeat", "created event, %v", event)
+		logp.Debug("s3awslogbeat", "created event, %v", event)
 		events.Records = append(events.Records, event)
 	}
 	logp.Info("Finished reading rows into VPCFlowLog events: s3://%s/%s", m.S3.Bucket.Name, m.S3.Object.Key)
@@ -312,7 +312,7 @@ func (logbeat *S3AwsLogBeat) getRowIndexValue(field string) (int) {
 		returnValue = index
 	}
 	/* Too noisy even for debug mode
-	logp.Debug("vpcflowlogbeat", "getRowIndexValue %v yields %v", field, returnValue) */
+	logp.Debug("s3awslogbeat", "getRowIndexValue %v yields %v", field, returnValue) */
 	return returnValue
 }
 
@@ -321,5 +321,5 @@ func (logbeat *S3AwsLogBeat) createFieldMap(headerRow ...string) {
 	for i, h := range headerRow {
 		logbeat.csvFields[h] = i
 	}
-	logp.Debug("vpcflowlogbeat", "CSV Fields Parsed: %v", logbeat.csvFields)
+	logp.Debug("s3awslogbeat", "CSV Fields Parsed: %v", logbeat.csvFields)
 }


### PR DESCRIPTION
This completes the work needed to support GuardDuty findings in S3 buckets.